### PR TITLE
feat: /channels/:displayName route now can differentiate whether the …

### DIFF
--- a/src/components/signup.js
+++ b/src/components/signup.js
@@ -25,7 +25,7 @@ export default class SignUp extends Component {
         firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL)
           .then(() => firebase.auth().createUserWithEmailAndPassword(email, password))
 
-          db.collection('jammers').doc(`${email}`).set({
+          db.collection('jammers').doc(`${displayName}`).set({
             email,
             firstName,
             lastName,

--- a/src/components/stream-page.js
+++ b/src/components/stream-page.js
@@ -6,7 +6,7 @@ import db from '../firebase';
 
 
 
-// To get here, need to have visited /channels/:streamerDisplayName
+// To get here, need to have visited /channels/:displayName
 // Using props.match.params.streamerDisplayName(?) we can pull displayName from URL and use that to determine the user being viewed
 // If the logged in user is the user in the URL, offer option start/end stream.
 // Otherwise, let them view only.
@@ -20,18 +20,23 @@ export default class StreamPage extends Component {
   }
 
   async componentDidMount(){
-    // const user = await firebase.auth().currentUser;
-    // console.log(user);
-    const jammer = await db.collection('jammers').get()
+    const channelOwner = this.props.match.params.displayName;
+    const jammerRef = await db.collection('jammers').doc(`${channelOwner}`).get()
+    const jammer = await jammerRef.data() || {};
     await firebase.auth().onAuthStateChanged(user => {
-      // if (user.email)
+      if (user.email === jammer.email) this.setState( { isStreamer: true } )
     });
+    console.log('state check: ', this.state);
   }
 
 
   render(){
+    const { isStreamer } = this.state;
     return (
-      <div>This is going to be an amazing full stream page</div>
+      isStreamer ?
+        <div>Welcome to your stream page, streamer!</div> :
+        <div>Welcome to the streamer's page, viewer!</div>
+
     )
   }
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -14,7 +14,7 @@ export default class Routes extends Component {
         <Route exact path="/login" component={Login} />
         <Route exact path="/streamer" component={StreamerVid} />
         <Route exact path="/viewer" component={ViewerVid} />
-        <Route exact path="/stream" component={StreamPage} />
+        <Route exact path="/channels/:displayName" component={StreamPage} />
       </Switch>
     );
   }


### PR DESCRIPTION
…visitor is the streamer or the viewer

## What did you change?
- routes.js, stream-page.js, signup.js

## What did it fix or what is now possible because of your change?
- /channels/:displayName route now can differentiate whether the visitor is the streamer or the viewer

## Are there any questions you had about the implementation or other possibilities you'd like the reviewers to consider?
- Our firebase DB had to be updated. Documents are set by displayName instead of email address
