### PR TITLE
bugfix: Updated streamer-vid and viewer-vid components to handle disconnect

### DIFF
--- a/src/components/viewer-vid.js
+++ b/src/components/viewer-vid.js
@@ -3,60 +3,73 @@ import React, { Component } from 'react';
 import * as firebase from 'firebase';
 
 export default class ViewerVid extends Component {
-  // constructor () {
-  //   super();
-  // }
+  constructor () {
+    super();
+    this.state = {
+      peer: '',
+      conn: null,
+      call: null,
+      stream: null
+    }
+  }
+
+  // This func it bound to state so that it can be used to store the incomming call
+  // on state when a streamer calls to send viewer the stream. We want to store the
+  // call so that we can properly destroy it when the connection ends
+  onCallAnswerCallHandleStreamAndSetState = (call, myVideoComponent) => {
+    this.setState({
+      call: call
+    })
+    call.answer();
+    call.on('stream', (stream) => this.onStreamHandleStreamAndSetState(stream, myVideoComponent) );
+  }
+
+  // This func it bound to state so that it can be used to store the incomming stream
+  // on state when a streamer calls to send viewer the stream. We want to store the
+  // stream so that we can properly destroy it when the connection ends
+  onStreamHandleStreamAndSetState = (stream, myVideoComponent) => {
+    this.setState({
+      stream: stream
+    })
+    myVideoComponent.srcObject = stream;
+  }
 
   componentDidMount() {
-
-    firebase.auth().onAuthStateChanged(user => {
-      if (user) {
-        //console.log('USER HERE!: ', user);
-      }
-    });
-
     const { displayName } = this.props
-    console.log('PROPS: ', displayName);
-    // let viewerPeerId =
-    //   'viewerJavierLilahJackie' + Math.floor(Math.random() * 1000);
 
-    // ice servers are used by webrtc / peerjs to establish the connection to the browser clients
-    // when they are behind routers that sheild private networks from the public internet - when
-    // peerJS makes connection it uses stun server to identify its external IP and then does some
-    // math on how to get from that IP, through the private network to the users browser - then it
-    // sends that to the peer its trying to connect to.
-    // peerJS recommends we setup our own, and we had identified these settings when we were mucking
-    // with webRTC
-    const iceServers = {
+    const iceServers = { // ** for explanation of ice servers see footnote
        'iceServers': [
-         { 'urls': 'stun:stun.services.mozilla.com' },
          { 'urls': 'stun:stun.l.google.com:19302' },
          { 'urls': 'turn:numb.viagenie.ca', 'credential': 'webrtc', 'username': 'javier3@gmail.com' }
         ] };
 
     const peer = new Peer({host: 'jampspace-01-peerjs-01.herokuapp.com', port: 443, config: iceServers, secure: true});
+    this.setState({peer});
     console.log('peer created', peer);
 
     peer.on('open', id => {
       console.log('my id is ', id);
     });
 
-    // omri suggested that we may need to use the connection to properly disconnect when a user closes the view - commenting out now b/c of the linter
-    // commenting the line below out caused no viewer connection to be established
     let conn = peer.connect(displayName);
-    // 'viewerJavierLilahJackie'
+    this.setState({conn});
 
-    peer.on('call', function(call) {
-      // Answer the call, providing our mediaStream
-      call.answer();
-      console.log('call answered');
-      call.on('stream', function(stream) {
-        myVideo.srcObject = stream;
-        console.log('stream added to video object');
-      });
-    });
+    const myVideoComponent = document.getElementById('myVideo');
 
-    const myVideo = document.getElementById('myVideo');
+    peer.on('call', (call) => this.onCallAnswerCallHandleStreamAndSetState(call, myVideoComponent) );
+  }
+
+  async componentWillUnmount(){
+    const { conn, call, peer, stream } = this.state;
+
+    // need to figure out if how to properly disconnect and hangup call
+    // conn.disconnect() ?
+    // call.hangup() ?
+
+    peer.destroy();
+    console.log('streamer-vid.js | peer destroyed')
+    stream && stream.getTracks().forEach(track => track.stop())
+    console.log('streamer-vid.js | tracks stopped')
   }
 
   render() {
@@ -67,3 +80,12 @@ export default class ViewerVid extends Component {
     );
   }
 }
+
+// ** ICE SERERS :
+// Ice servers are used by webrtc / peerjs to establish the connection to the browser clients
+// when they are behind routers that sheild private networks from the public internet - when
+// peerJS makes connection it uses stun server to identify its external IP and then does some
+// math on how to get from that IP, through the private network to the users browser - then it
+// sends that to the peer its trying to connect to.
+// peerJS recommends we setup our own, and we had identified these settings when we were mucking
+// with webRTC


### PR DESCRIPTION
## What did you change?

Updated streamer-vid and viewer-vid components to properly destroy peers and correspoding streams when the streamer / viewer disconnects. Need to circle back and determine what we should do with the other objects involved - on the streamer side there is a connection and on the viewer side a call and a connection
